### PR TITLE
Remove the first "biomedical" from the title

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -1,5 +1,5 @@
 ---
-title: "Reusing label functions to extract multiple types of biomedical relationships from biomedical abstracts at scale"
+title: "Reusing label functions to extract multiple types of relationships from biomedical abstracts at scale"
 keywords:
   - machine learning
   - weak supervision


### PR DESCRIPTION
There was a suggestion for removing the first "biomedical" from the title. If no push back on this suggested change, feel free to approve.